### PR TITLE
Reducedmemoryuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ Add a constant at the beginning of a.js with the following format:
 `const lightOutX = [<4x4 array of true/false>, 0, []]`  
 Once you have the const you can call it at the end with:  
 `solve(lightOutX, [])`
+
+## What is b.js?
+b.js is a.js with reduced memory use. Instead of storing the full child lights out structure, each child only holds the cost and all the clicks so far. The lights out array is then constructed when it is being treated as the parent node.

--- a/b.js
+++ b/b.js
@@ -1,0 +1,97 @@
+// True means a light is on.
+const lightOut = [[[false, true, true, true], [false, true, true, false], [true, true, false, true], [false, false, false, false]], 0, []]
+//const lightOut = [[[true, true, true, true, true], [false, false, false, true, false], [true, false, true, false, true], [false, true, false, true, true], [false, false, false, false, false]], 0, []]
+const lightOut1 = [[[true, false, true, false], [true, false, true, true], [false, false, false, true], [true, false, false, false]], 0, []]
+const lightOut2 = [[[true, false, true, true], [false, false, true, true], [false, true, true, false], [false, true, true, false]], 0, []]
+// All examples were taken from: http://perfectweb.org/ddo/solver/vale_puzzle.html to prove validity
+// We opted to use 4x4 instead of 5x5 because we were running out of memory with 5x5 examples due to it
+// having a potential 25! children (supposedly 24!+1 with a-star)
+
+// Recursively searches for the result
+solve = (source, parent, children) => {
+    //console.log(source)
+    const realparent = buildParent(source, parent[1])
+    //console.log(realparent)
+    if(validate(realparent)){
+        console.log(realparent)
+        console.log(parent)
+        return
+    }
+    let child = children.concat(generateChildren(realparent, parent)).sort(comparator)
+    const newparent = child.shift()
+    //console.log(child)
+    //console.log(newparent)
+    solve(source, newparent, child)
+}
+
+// Validates the answer
+validate = (parent) => {
+    for(let i = 0; i < parent.length; i++){
+        if(parent[i].includes(true)){
+            return false
+        }
+    }
+    return true
+}
+
+// Generates a child for every node not clicked so far
+generateChildren = (realparent, parent) => {
+    let newchildren = []
+    for (let i = 0; i < realparent.length; i++){
+        for (let j = 0; j < realparent.length; j++) {
+            let valid = true
+            for(let k = 0; k < parent[1].length; k++){
+                if(parent[1][k][0] == i && parent[1][k][1] == j){
+                    valid = false
+                }
+            }
+            if (valid) {
+                //console.log(parent)
+                const child = clickPos(realparent, [i, j])
+                newchildren.push([parent[0] + countLightsOn(child), parent[1].concat([[i, j]])])
+            }
+        }
+    }
+    return newchildren;
+}
+
+// Simple comparator for costs
+comparator = (i, j) => {
+    return i[0] - j[0]
+}
+
+// Switches the lights on/off for a given child 
+clickPos = (parent, pos) => {
+    let result = JSON.parse(JSON.stringify(parent));
+    parent[pos[0]] != undefined && parent[pos[0]][pos[1]] != undefined  ? result[pos[0]][pos[1]] = !parent[pos[0]][pos[1]] : undefined;
+    parent[pos[0]-1] != undefined  && parent[pos[0]-1][pos[1]] != undefined  ? result[pos[0]-1][pos[1]] = !parent[pos[0]-1][pos[1]] : undefined;
+    parent[pos[0]+1] != undefined  && parent[pos[0]+1][pos[1]] != undefined  ? result[pos[0]+1][pos[1]] = !parent[pos[0]+1][pos[1]] : undefined;
+    parent[pos[0]] != undefined  && parent[pos[0]][pos[1]-1] != undefined  ? result[pos[0]][pos[1]-1] = !parent[pos[0]][pos[1]-1] : undefined;
+    parent[pos[0]] != undefined  && parent[pos[0]][pos[1]+1] != undefined  ? result[pos[0]][pos[1]+1] = !parent[pos[0]][pos[1]+1] : undefined;
+    return result;
+}
+
+// Counts the number of lights on in a child to determine the cost
+countLightsOn = (child) => {
+    let lightsOn = 0;
+    for (let i = 0; i < child.length; i++) {
+        for (let j = 0; j < child[i].length; j++) {
+            if (child[i][j]) lightsOn++;
+        }
+    }
+    return lightsOn;
+}
+
+buildParent = (source, parentclicked) => {
+    let newpar = JSON.parse(JSON.stringify(source))
+    for(let i = 0; i < parentclicked.length; i++){
+        newpar = clickPos(newpar, parentclicked[i])
+    }
+    //console.log(newpar)
+    return newpar
+}
+
+// Tests
+solve(lightOut[0], [0, []], [])
+solve(lightOut1[0], [0, []], [])
+solve(lightOut2[0], [0, []], [])


### PR DESCRIPTION
Add b.js which reduces the overall memory usage of a.js by only constructing the lights-out array as necessary. It also generalizes some of the code so 3x3 arrays can also be solved. Even with this setup, it still runs out of memory when run against 5x5 arrays.